### PR TITLE
chore: fix build reverting arrow function

### DIFF
--- a/build/doc/index.js
+++ b/build/doc/index.js
@@ -18,7 +18,7 @@ gulp.task('build:doc:set-base-url', () =>
   gulp
     .src('static/index.html')
     .pipe(
-      $.dom(() => {
+      $.dom(function setUrl() {
         const header = this.querySelector('head');
         const base = this.createElement('base');
         base.href = 'https://ocean-ds.github.io/ocean-tokens/';


### PR DESCRIPTION
## Description

Fix `yarn build` reverting an arrow function added in doc/index.js, replacing by a named function, that works with a correct "this" scope. 

Fixes # (issue)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Running `yarn build` and `yarn lint`

## Screenshots:

<img width="862" alt="Screenshot 2023-01-11 at 12 30 43" src="https://user-images.githubusercontent.com/28522/211847125-b1b8d9e6-1af5-444e-aebe-ea9b97cc6b3b.png">
